### PR TITLE
Various

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+  - "3.8"
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ install:
 script:
   # build the wheels, put them into './wheelhouse'
   - python3 -m cibuildwheel --output-dir wheelhouse
-  - |
-    if [[ "$TRAVIS_OS_NAME" = linux ]]; then
-      python3 tools/generate-stubs.py wheelhouse linux pybiginteger
-    fi
+  #- |
+  #  if [[ "$TRAVIS_OS_NAME" = linux ]]; then
+  #    python3 tools/generate-stubs.py wheelhouse linux pybiginteger
+  #  fi
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ install:
 script:
   # build the wheels, put them into './wheelhouse'
   - python3 -m cibuildwheel --output-dir wheelhouse
+  - |
+    if [[ "$TRAVIS_OS_NAME" = linux ]]; then
+      python3 tools/generate-stubs.py wheelhouse linux pybiginteger
+    fi
 
 deploy:
   provider: releases

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(BigIntegerCpp VERSION 1.0)
+project(BigIntegerCpp VERSION 1.1)
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ set(CMAKE_CXX_STANDARD 17)
 
 include(FetchContent)
 
-option(BUILD_PYTHON_BINDINGS "Build the Python bindings" OFF)
-option(BUILD_SHARED_LIB "Build a shared library" ON)
-option(BUILD_STATIC_LIB "Build a static library" OFF)
+option(BIGINTEGER_BUILD_PYTHON_BINDINGS "Build the Python bindings" OFF)
+option(BIGINTEGER_BUILD_SHARED_LIB "Build a shared library" ON)
+option(BIGINTEGER_BUILD_STATIC_LIB "Build a static library" OFF)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/public/bigintegercpp/version.h)
 
@@ -36,7 +36,7 @@ set(bigintegercpp_PRIVATE_INCLUDE
 # expose ${bigintegercpp_INCLUDE_DIRS} for downstream projects to consume
 set(bigintegercpp_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include/public/ CACHE INTERNAL "")
 
-if (BUILD_SHARED_LIB OR BUILD_STATIC_LIB OR BUILD_TESTING)
+if (BIGINTEGER_BUILD_SHARED_LIB OR BIGINTEGER_BUILD_STATIC_LIB OR BUILD_TESTING)
     add_library(BigIntegerCpp-obj SHARED ${bigintegercpp_SOURCES})
     target_include_directories(BigIntegerCpp-obj
             PUBLIC
@@ -48,7 +48,7 @@ if (BUILD_SHARED_LIB OR BUILD_STATIC_LIB OR BUILD_TESTING)
     set_target_properties(BigIntegerCpp-obj PROPERTIES
             POSITION_INDEPENDENT_CODE ON
             )
-    if (BUILD_SHARED_LIB)
+    if (BIGINTEGER_BUILD_SHARED_LIB)
         add_library(BigIntegerCpp-shared SHARED $<TARGET_OBJECTS:BigIntegerCpp-obj>)
         set_target_properties(BigIntegerCpp-shared
                 PROPERTIES
@@ -56,13 +56,13 @@ if (BUILD_SHARED_LIB OR BUILD_STATIC_LIB OR BUILD_TESTING)
                 )
         add_library(BigIntegerCpp::BigIntegerCpp ALIAS BigIntegerCpp-shared)
     endif()
-    if (BUILD_STATIC_LIB)
+    if (BIGINTEGER_BUILD_STATIC_LIB)
         add_library(BigIntegerCpp-static STATIC $<TARGET_OBJECTS:BigIntegerCpp-obj>)
         add_library(BigIntegerCpp::BigIntegerCpp-static ALIAS BigIntegerCpp-static)
     endif()
 endif()
 
-if (BUILD_PYTHON_BINDINGS)
+if (BIGINTEGER_BUILD_PYTHON_BINDINGS)
     add_subdirectory(bindings/python)
 endif()
 
@@ -73,21 +73,21 @@ endif()
 ##############
 # Installation
 
-if (BUILD_SHARED_LIB OR BUILD_STATIC_LIB OR BUILD_TESTING)
+if (BIGINTEGER_BUILD_SHARED_LIB OR BIGINTEGER_BUILD_STATIC_LIB OR BUILD_TESTING)
     include(GNUInstallDirs)
 
 
     # can't use generator expression for target list
-    if (BUILD_SHARED_LIB AND BUILD_STATIC_LIB)
+    if (BIGINTEGER_BUILD_SHARED_LIB AND BIGINTEGER_BUILD_STATIC_LIB)
         install(TARGETS BigIntegerCpp-shared BigIntegerCpp-static
                 EXPORT BigIntegerCpp-targets
                 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    elseif (BUILD_SHARED_LIB)
+    elseif (BIGINTEGER_BUILD_SHARED_LIB)
         install(TARGETS BigIntegerCpp-shared
                 EXPORT BigIntegerCpp-targets
                 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    elseif (BUILD_STATIC_LIB)
+    elseif (BIGINTEGER_BUILD_STATIC_LIB)
         install(TARGETS BigIntegerCpp-static
                 EXPORT BigIntegerCpp-targets
                 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](https://raw.githubusercontent.com/CityOfZion/visual-identity/develop/_CoZ%20Branding/_Logo/_Logo%20icon/_PNG%20200x178px/CoZ_Icon_DARKBLUE_200x178px.png)
     
 # BigIntegerCpp
-[![CircleCI](https://circleci.com/gh/CityOfZion/neo3-python.svg?style=shield)](https://circleci.com/gh/CityOfZion/neo3-python)
+[![CircleCI](https://circleci.com/gh/CityOfZion/BigIntegerCpp.svg?style=shield)](https://circleci.com/gh/CityOfZion/BigIntegerCpp)
 
 A C++ port of the [C# BigInteger](https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger?view=netcore-3.1) class, with bindings for Python.
 
@@ -18,11 +18,11 @@ The default configuration builds a shared library
 
 You can define various options during the configure stage to control the output
 
-| Var                   | Default | Comment                      |
-|-----------------------|---------|------------------------------|
-| BUILD_SHARED_LIB      | ON      |                              |
-| BUILD_STATIC_LIB      | OFF     |                              |
-| BUILD_TESTING         | OFF     |                              |
+| Var                              | Default | Comment                      |
+|----------------------------------|---------|------------------------------|
+| BIGINTEGER_BUILD_SHARED_LIB      | ON      |                              |
+| BIGINTEGER_BUILD_STATIC_LIB      | OFF     |                              |
+| BIGINTEGER_BUILD_TESTING         | OFF     |                              |
 
 ### Building the bindings
 

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -33,5 +33,5 @@ If it detects the wrong version or instance (e.g. in case you're using a virtual
 
 The following example uses the virtual environment found under `<project root>/venv/` executing the commands from `<project root>/build/`. 
 
-     cmake -D PYTHON_EXECUTABLE=../venv/bin/python3 -D BUILD_PYTHON_BINDINGS=ON ..
+     cmake -D PYTHON_EXECUTABLE=../venv/bin/python3 -D BIGINTEGER_BUILD_PYTHON_BINDINGS=ON ..
      cmake --build . 

--- a/bindings/python/python-bindings.cpp
+++ b/bindings/python/python-bindings.cpp
@@ -3,7 +3,11 @@
 #include "../../include/public/bigintegercpp/version.h"
 namespace py = pybind11;
 
-BigInteger to_biginteger(py::int_& value, bool is_signed = true, bool is_bigendian = false) {
+BigInteger to_biginteger(py::int_& value, bool is_bigendian = false) {
+    bool is_signed = false;
+    if (value < py::int_(0))
+        is_signed = true;
+
     if (value.is(py::int_(0)))
         return BigInteger::zero();
 
@@ -16,7 +20,7 @@ BigInteger to_biginteger(py::int_& value, bool is_signed = true, bool is_bigendi
         throw std::invalid_argument("failed to cast");
     } else {
         if (!is_signed)
-            return BigInteger(buffer);
+            return BigInteger(buffer, true);
 
         // signed cases in C# use the shortest 2 complement representation possible, Python doesn't, thus we convert
         unsigned char high_byte;

--- a/bindings/python/python-bindings.cpp
+++ b/bindings/python/python-bindings.cpp
@@ -1,7 +1,6 @@
 #include <pybind11/pybind11.h>
 #include "../../include/public/bigintegercpp/BigInteger.h"
 #include "../../include/public/bigintegercpp/version.h"
-#include <chrono>
 namespace py = pybind11;
 
 BigInteger to_biginteger(py::int_& value, bool is_signed = true, bool is_bigendian = false) {
@@ -64,28 +63,24 @@ py::int_ to_py_int(const BigInteger& value, bool is_signed = true, bool is_bigen
     return py::reinterpret_steal<py::int_>(obj);
 }
 
-static constexpr auto VERSION_BINDINGS = "1.1";
+static constexpr auto VERSION_BINDINGS = "1.2";
 
 PYBIND11_MODULE(pybiginteger, m) {
     m.doc() = "A C++ port of the C# BigInteger class";
     py::class_<BigInteger>(m, "BigInteger")
             .def_property_readonly_static("__version__", [](py::object self) { return BIGINTEGERCPP_VERSION; }, R"(C++ code version)")
             .def_property_readonly_static("__version_bindings__", [](py::object self){ return VERSION_BINDINGS; }, R"(Binding version)")
-            .def(py::init<int32_t>(), py::arg("value"))
-            .def(py::init<uint32_t>(), py::arg("value"))
-            .def(py::init<int64_t>(), py::arg("value"))
-            .def(py::init<uint64_t>(), py::arg("value"))
             .def(py::init([](py::int_& i) {
-                return to_biginteger(i);
+              return to_biginteger(i);
             }), py::arg("value"))
             .def(py::init([](py::buffer const b) {
-                py::buffer_info info = b.request();
-                if (info.format != py::format_descriptor<unsigned char>::format() || info.ndim != 1)
-                    throw std::runtime_error("Incompatible buffer format!");
+              py::buffer_info info = b.request();
+              if (info.format != py::format_descriptor<unsigned char>::format() || info.ndim != 1)
+                  throw std::runtime_error("Incompatible buffer format!");
 
-                auto data_ptr = static_cast<unsigned char *>(info.ptr);
-                std::vector<unsigned char> data(data_ptr, data_ptr + info.size);
-                return BigInteger(data);
+              auto data_ptr = static_cast<unsigned char *>(info.ptr);
+              std::vector<unsigned char> data(data_ptr, data_ptr + info.size);
+              return BigInteger(data);
             }), py::arg("value"))
             .def("__lt__", [](BigInteger& self, BigInteger& other) {
                 return self < other;
@@ -324,5 +319,6 @@ PYBIND11_MODULE(pybiginteger, m) {
                 return BigInteger::log(to_biginteger(value), base_value);
                 }, py::arg("value"), py::arg("base_value"))
             .def_static("log10", &BigInteger::log10, py::arg("value"))
-            .def_static("log10", [](py::int_& value) { return BigInteger::log10(to_biginteger(value)); }, py::arg("value"));
+            .def_static("log10", [](py::int_& value) { return BigInteger::log10(to_biginteger(value)); }, py::arg("value"))
+            .def_property_readonly("sign", &BigInteger::sign);
 }

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,9 @@ class CMakeBuild(build_ext):
 
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DPYTHON_EXECUTABLE=' + sys.executable,
-                      '-DBUILD_PYTHON_BINDINGS=ON',
-                      '-DBUILD_SHARED_LIB=OFF',
-                      '-DBUILD_STATIC_LIB=OFF',
+                      '-DBIGINTEGER_BUILD_PYTHON_BINDINGS=ON',
+                      '-DBIGINTEGER_BUILD_SHARED_LIB=OFF',
+                      '-DBIGINTEGER_BUILD_STATIC_LIB=OFF',
                       '-DBUILD_TESTING=OFF']
 
         # cfg = 'Debug' if self.debug else 'Release'

--- a/src/BigInteger.cpp
+++ b/src/BigInteger.cpp
@@ -1212,7 +1212,7 @@ byte_array BigInteger::to_byte_array(GetBytesMode mode, bool isUnsigned, bool is
     }
 
     if (isUnsigned && sign < 0) {
-        throw std::runtime_error("Overflow error can't have unsigned & sing < 0");
+        throw std::runtime_error("Overflow error can't have unsigned & sign < 0");
     }
 
     byte highByte;

--- a/tools/fix-stubs.py
+++ b/tools/fix-stubs.py
@@ -1,0 +1,29 @@
+import sys
+
+patterns = [
+    (': buffer', ': bytes'),
+    ('neo3vm::', ''),
+    ('int_', 'int'),
+    ('bool_', 'bool'),
+    ('from numpy import float64', ''),
+    ('_Shape = Tuple[int, ...]', '')
+]
+
+def main():
+    with open(sys.argv[1], 'r') as f:
+        lines = f.readlines()
+
+    for i, line in enumerate(lines):
+        for pattern in patterns:
+            if pattern[0] in line:  # type: str
+                lines[i] = line.replace(pattern[0], pattern[1])
+
+    # add missing import
+    if 'neo3vm' in sys.argv[1]:
+        lines.insert(2, 'from pybiginteger import BigInteger\n')
+
+    with open(sys.argv[1], 'w') as f:
+        f.writelines(lines)
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate-stubs.py
+++ b/tools/generate-stubs.py
@@ -1,0 +1,65 @@
+"""
+Build stub files using just 1 interpreter (python 3.8 hardcoded)
+and using a specified platform ('macosx', 'linux' or 'win')
+
+Syntax:
+    generate-stubs <wheel dir> <platform> <extension name>
+
+Example:
+    generate-stubs ./dist macosx pybiginteger
+"""
+
+import sys
+import os
+import subprocess
+import re
+
+
+def install_pkg(package_name, wheel_dir, platform):
+    for file in os.listdir(wheel_dir):
+        if 'cp38' in file and platform in file and file.endswith('.whl'):
+            # install without dependencies, because it depends on the stub files which we're building here
+            subprocess.run(['pip', 'install', wheel_dir + '/' + file, '--no-dependencies', '--force-reinstall'])
+            version = re.search(f"{package_name}-(.+?)-.*", file).group(1)
+            return version
+
+
+def create_setup(package_name, package_version, wheel_dir):
+    with open(f"{wheel_dir}/setup.py", "w") as setuppy:
+        setuppy.write("""from setuptools import setup
+setup(
+    name='{package_name}-stubs',
+    maintainer="Erik van den Brink",
+    maintainer_email="erik@coz.io",
+    description="PEP 561 type stubs for {package_name}",
+    version='{package_version}',
+    packages=['{package_name}-stubs'],
+    # PEP 561 requires these
+    install_requires=['{package_name}=={package_version}'],
+    include_package_data=True
+)
+""".format(package_name=package_name, package_version=package_version))
+
+    with open(f"{wheel_dir}/MANIFEST.in", "w") as manifest_setup:
+        manifest_setup.write(f"""include {package_name}-stubs/*""")
+
+
+def main():
+    wheel_dir = sys.argv[1]
+    platform = sys.argv[2]
+    package_name = sys.argv[3]
+    # prepare by installing the extension and stubgen toll
+    subprocess.check_call(['python', '-m', 'pip', 'install', 'pybind11-stubgen'])
+    package_version = install_pkg(package_name, wheel_dir, platform)
+    # generate stubs
+    subprocess.check_call(['pybind11-stubgen', '--skip-signature-downgrade', '--no-setup-py', '-o', '.', package_name], cwd=wheel_dir)
+    # create setup.py with proper information
+    create_setup(package_name, package_version, wheel_dir)
+    # polish up stub files
+    subprocess.check_call(['python', './tools/fix-stubs.py', f"./{wheel_dir}/{package_name}-stubs/__init__.pyi"])
+    # build wheel
+    subprocess.check_call(['python', 'setup.py', 'bdist_wheel', '--dist-dir', '.'], cwd=wheel_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- expose sign property
- remove int constructors and always convert ourselves for faster lookup
- remove unused import
- fix readme circleci badge pointing to wrong repository
- Add "BIGINTEGER_" prefix to CMake build variables to make the project easier controllable downstream
- Add stub generation code